### PR TITLE
Removing mock_apps tests as it is not necessary

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -10,7 +10,6 @@ PWD = os.path.abspath(os.path.dirname(__file__))
 
 if __name__ == '__main__':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'test_settings')
-    sys.path.append('./mock_apps')
     sys.path.append(PWD)
     try:
         from django.core.management import execute_from_command_line  # pylint: disable=wrong-import-position

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,6 @@ addopts = --cov edx_manager_access_api --cov-report term-missing --cov-report xm
 norecursedirs = .* docs requirements site-packages
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}/mock_apps/
 deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1


### PR DESCRIPTION
**Description:** 
This PR is reverting the tox.in, and manage.py files to remove definitions of the mock_apps directory. The directory was intended to be used as a testing mechanism putting new tests in there was is not necessary, so I have removed it.